### PR TITLE
PR for US_testing_DDL_Compared_drift_db_1_ISS-640011

### DIFF
--- a/US_testing/DDL/Compared/drift_db_1/ISS-640011/ISS-640011
+++ b/US_testing/DDL/Compared/drift_db_1/ISS-640011/ISS-640011
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email);


### PR DESCRIPTION
This PR adds the SQL file ISS-640011 in the respective folder structure.